### PR TITLE
Display warnings if used rubric is being updated and mark instances for regrade

### DIFF
--- a/grade/grading/form/rubric/edit.php
+++ b/grade/grading/form/rubric/edit.php
@@ -44,16 +44,16 @@ $PAGE->set_url(new moodle_url('/grade/grading/form/rubric/edit.php', array('area
 $PAGE->set_title(get_string('definerubric', 'gradingform_rubric'));
 $PAGE->set_heading(get_string('definerubric', 'gradingform_rubric'));
 
-$mform = new gradingform_rubric_editrubric(null, array('areaid' => $areaid, 'context' => $context));
+$mform = new gradingform_rubric_editrubric(null, array('areaid' => $areaid, 'context' => $context, 'allowdraft' => !$controller->has_active_instances()));
 $data = $controller->get_definition_for_editing();
 $returnurl = optional_param('returnurl', $manager->get_management_url(), PARAM_LOCALURL);
 $data->returnurl = $returnurl;
 $mform->set_data($data);
 if ($mform->is_cancelled()) {
     redirect($returnurl);
-} else if ($mform->is_submitted() && $mform->is_validated()) {
-    $data = $mform->get_data();
-    $controller->update_definition($data);
+} else if ($mform->is_submitted() && $mform->is_validated() && !$mform->need_confirm_regrading($controller)) {
+    // everything ok, validated, re-grading confirmed if needed. Make changes to the rubric
+    $controller->update_definition($mform->get_data());
     redirect($returnurl);
 }
 

--- a/grade/grading/form/rubric/lang/en/gradingform_rubric.php
+++ b/grade/grading/form/rubric/lang/en/gradingform_rubric.php
@@ -69,3 +69,18 @@ $string['err_nodescription'] = 'Criterion description can not be empty';
 $string['err_nodefinition'] = 'Level definition can not be empty';
 $string['err_scoreformat'] = 'Number of points for each level must be a valid non-negative number';
 $string['err_totalscore'] = 'Maximum number of points possible when graded by the rubric must be more than zero';
+
+$string['regrademessage1'] = 'You are about to save changes to the rubric that has already been used for grading. Please indicate whether your changes
+                are significant and students grades need to be reviewed.
+                If students already graded are marked for re-grading their
+                current grades remain in gradebook but the students will not see the rubric grading before teacher updates it.';
+$string['regrademessage5'] = 'You are about to save significant changes to the rubric that has already been used for grading. Please note that all students already graded will be marked for re-grading.
+                The
+                current grades remain in gradebook but the students will not see the rubric grading before teacher updates it.';
+$string['regradeoption0'] = 'Do not mark for regrade';
+$string['regradeoption1'] = 'Mark for regrade';
+
+$string['needregrademessage'] = 'Rubric definition was changed after this student had been graded. You must update the grade otherwise it will not be shown to student.';
+$string['rubricnotcompleted'] = 'You have to select a feedback on each rubric criterion';
+
+$string['backtoediting'] = 'Back to editing';

--- a/grade/grading/form/rubric/rubriceditor.php
+++ b/grade/grading/form/rubric/rubriceditor.php
@@ -44,6 +44,23 @@ class MoodleQuickForm_rubriceditor extends HTML_QuickForm_input {
         return 'default';
     }
 
+    protected $regradeconfirmation = false;
+    /**
+     * Specifies that confirmation about re-grading needs to be added to this rubric editor.
+     * $changelevel is saved in $this->regradeconfirmation and retrieved in toHtml()
+     *
+     * @see gradingform_rubric_controller::update_or_check_rubric()
+     * @param int $changelevel
+     */
+    function add_regrade_confirmation($changelevel) {
+        $this->regradeconfirmation = $changelevel;
+    }
+
+    /**
+     * Returns html string to display this element
+     *
+     * @return string
+     */
     function toHtml() {
         global $PAGE;
         $html = $this->_getTabs();
@@ -68,6 +85,12 @@ class MoodleQuickForm_rubriceditor extends HTML_QuickForm_input {
             } else {
                 $mode = gradingform_rubric_controller::DISPLAY_PREVIEW;
             }
+        }
+        if ($this->regradeconfirmation) {
+            if (!isset($data['regrade'])) {
+                $data['regrade'] = 1;
+            }
+            $html .= $renderer->display_regrade_confirmation($this->getName(), $this->regradeconfirmation, $data['regrade']);
         }
         if ($this->validationerrors) {
             $html .= $renderer->notification($this->validationerrors, 'error');
@@ -111,6 +134,14 @@ class MoodleQuickForm_rubriceditor extends HTML_QuickForm_input {
                     $return['options'][$option] = $value['options'][$option];
                 } else {
                     $return['options'][$option] = null;
+                }
+            }
+        }
+        if (is_array($value)) {
+            // for other array keys of $value no special treatmeant neeeded, copy them to return value as is
+            foreach (array_keys($value) as $key) {
+                if ($key != 'options' && $key != 'criteria') {
+                    $return[$key] = $value[$key];
                 }
             }
         }

--- a/grade/grading/form/rubric/styles.css
+++ b/grade/grading/form/rubric/styles.css
@@ -108,3 +108,10 @@
 .gradingform_rubric .criterion .description.error,
 .gradingform_rubric .criterion .levels .level .definition.error,
 .gradingform_rubric .criterion .levels .level .score.error {background:#FFDDDD;}
+
+/**
+ *
+ */
+
+.gradingform_rubric-regrade {padding:10px;background:#FFDDDD;border:1px solid #F00;margin-bottom:10px;}
+.gradingform_rubric-error {color:red;font-weight:bold;}

--- a/mod/assignment/lib.php
+++ b/mod/assignment/lib.php
@@ -335,7 +335,7 @@ class assignment_base {
         $grade_str = '<div class="grade">'. get_string("grade").': '.$grade->str_long_grade. '</div>';
         if (!empty($submission) && $controller = get_grading_manager($this->context, 'mod_assignment', 'submission')->get_active_controller()) {
             $controller->set_grade_range(make_grades_menu($this->assignment->grade));
-            echo $controller->render_grade($PAGE, $submission->id, $item, $grade_str);
+            echo $controller->render_grade($PAGE, $submission->id, $item, $grade_str, has_capability('mod/assignment:grade', $this->context));
         } else {
             echo $grade_str;
         }


### PR DESCRIPTION
- If a used rubric being updated, teacher (moderator) is notified
- If the changes are significant, all instances automatically marked for regrade
- if the changes are minor (texts, options or sortorder), teacher can choose whether to mark for regrade or not
- The instances marked for regrade can be re-graded but students are not able to see the rubric
- when grading a message appears if the instance is marked for regrade and is not visible to students
