### PR TITLE
MDL-61302 policy: View a policy document version

### DIFF
--- a/admin/tool/policy/classes/output/guestconsent.php
+++ b/admin/tool/policy/classes/output/guestconsent.php
@@ -52,6 +52,7 @@ class guestconsent implements renderable, templatable {
 
         $data = (object) [];
         $data->pluginbaseurl = (new moodle_url('/admin/tool/policy'))->out(true);
+        $data->returnurl = qualified_me();
 
         $policies = \tool_policy\api::list_policies();
         foreach ($policies as $policy) {

--- a/admin/tool/policy/classes/output/page_viewdoc.php
+++ b/admin/tool/policy/classes/output/page_viewdoc.php
@@ -1,0 +1,111 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provides {@link tool_policy\output\renderer} class.
+ *
+ * @package     tool_policy
+ * @category    output
+ * @copyright   2018 Sara Arjona <sara@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_policy\output;
+
+
+defined('MOODLE_INTERNAL') || die();
+
+use context_system;
+use moodle_url;
+use renderable;
+use renderer_base;
+use single_button;
+use templatable;
+use tool_policy\api;
+
+/**
+ * Represents a page for showing the given policy document version.
+ *
+ * @copyright 2018 Sara Arjona <sara@moodle.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class page_viewdoc implements renderable, templatable {
+
+    /** @var int $versionid Policy id for this page. */
+    protected $policyid = null;
+
+    /** @var int $versionid Version policy id for this page. */
+    protected $versionid = null;
+
+    /** @var string $url Return URL. */
+    protected $returnurl = null;
+
+    /** @var bool Can the user view draft versions. */
+    protected $canviewdraftrevision;
+
+    /**
+     * Construct this renderable.
+     * @param int $policyid The policy id for this page.
+     * @param int $versionid The version id to show.
+     * @param string $returnurl Return URL.
+     */
+    public function __construct($policyid, $versionid = 0, $returnurl = null) {
+        $this->policyid = $policyid;
+        $this->versionid = $versionid;
+        $this->returnurl = $returnurl;
+        $this->canviewdraftrevision = has_capability('tool/policy:managedocs', context_system::instance());
+    }
+
+    /**
+     * Export the page data for the mustache template.
+     *
+     * @param renderer_base $output renderer to be used to render the page elements.
+     * @return stdClass
+     */
+    public function export_for_template(renderer_base $output) {
+
+        $data = (object) [];
+        $data->error = [];
+        $data->pluginbaseurl = (new moodle_url('/admin/tool/policy'))->out(true);
+
+        $policy = api::list_policies($this->policyid)[$this->policyid];
+        if (empty($this->versionid) && !empty($policy->currentversionid)) {
+            // If versionid is not defined, get the one defined as current.
+            $this->versionid = $policy->currentversionid;
+        }
+
+        if (!empty($this->versionid)) {
+            $version = \tool_policy\api::get_policy_version($this->policyid, $this->versionid);
+            $version->status = \tool_policy\api::get_policy_version_status($this->policyid, $this->versionid);
+            if (isset($version->status) && ($version->status != \tool_policy\api::VERSION_STATUS_DRAFT || $this->canviewdraftrevision)) {
+                $data->version = $version;
+            } else {
+                $data->error[] = get_string('usercantviewdraftversion', 'tool_policy');
+            }
+        }
+
+        $data->navigation = array();
+        if (!empty($this->returnurl)) {
+            $backbutton = new single_button(
+               new moodle_url($this->returnurl),
+               get_string('back'), 'get'
+            );
+            $data->navigation[] = $output->render($backbutton);
+        }
+
+        return $data;
+    }
+}

--- a/admin/tool/policy/classes/page_helper.php
+++ b/admin/tool/policy/classes/page_helper.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Page helper.
+ *
+ * @package    tool_policy
+ * @copyright  2018 Sara Arjona (sara@moodle.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_policy;
+defined('MOODLE_INTERNAL') || die();
+
+use coding_exception;
+use context;
+use moodle_exception;
+use moodle_url;
+use core_user;
+use context_user;
+use context_course;
+use stdClass;
+
+/**
+ * Page helper.
+ *
+ * @package    tool_policy
+ * @copyright  2018 Sara Arjona (sara@moodle.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class page_helper {
+
+    /**
+     * Set-up a public page.
+     *
+     * Example:
+     * list($title, $subtitle) = page_helper::setup_for_public_page($url, $pagetitle);
+     * echo $OUTPUT->heading($title);
+     * echo $OUTPUT->heading($subtitle, 3);
+     *
+     * @param  moodle_url $url The current page.
+     * @param  string $subtitle The title of the subpage, if any.
+     * @return array With the following:
+     *               - Page title
+     *               - Page sub title
+     */
+    public static function setup_for_public_page(moodle_url $url, $subtitle = '') {
+        global $PAGE, $SITE;
+
+        $context = \context_system::instance();
+        $PAGE->set_context($context);
+
+        if (!empty($subtitle)) {
+            $title = $subtitle;
+        } else {
+            $title = get_string('policiesagreements', 'tool_policy');
+        }
+
+        $heading = $SITE->fullname;
+        $PAGE->set_pagelayout('standard');
+        $PAGE->set_url($url);
+        $PAGE->set_title($title);
+        $PAGE->set_heading($heading);
+
+        return array($title, $subtitle);
+    }
+}

--- a/admin/tool/policy/lang/en/tool_policy.php
+++ b/admin/tool/policy/lang/en/tool_policy.php
@@ -79,5 +79,6 @@ $string['template_site_name'] = 'Site policy';
 $string['template_thirdparties_content'] = '<h2>Sharing data with third parties</h2><p>This is the list of other institutions with whom personal data may be shared.</p><table class="generaltable"><thead><tr><th scope="col">Name</th><th scope="col">Purpose of data sharing</th><th scope="col">Data we share with them</th></tr></thead><tbody><tr><td><a href="https://example.com">Pandora\'s Box Ltd.</a></td><td>Regular database backup are stored in their data center and can be used to restore our school systems in case of damage.</td><td>All data we have in our database. Data are encrypted before being sent to them.</td></tr></tbody></table>';
 $string['template_thirdparties_name'] = 'Third parties policy example';
 $string['useracceptances'] = 'User acceptances';
+$string['usercantviewdraftversion'] = 'You don\'t have access to this policy document version because it is a draft.';
 $string['userpolicysettings'] = 'Policies';
 $string['usersaccepted'] = 'Users accepted';

--- a/admin/tool/policy/styles.css
+++ b/admin/tool/policy/styles.css
@@ -83,3 +83,9 @@
     text-decoration: underline;
     color: #f6a21d;
 }
+
+
+.policy-heading .policy-viewdoc-buttons {
+    text-align: center;
+    margin: 15px;
+}

--- a/admin/tool/policy/templates/guestconsent.mustache
+++ b/admin/tool/policy/templates/guestconsent.mustache
@@ -35,7 +35,7 @@ require(['jquery', 'tool_policy/jquery-eu-cookie-law-popup'], function($) {
                 // Get localised messages.
                 // TODO: Get valid policy version URL.
                 var textmessage = "{{# str }} guestconsentmessage, tool_policy {{/ str }}" +
-                   "<ul>{{#policies}}<li><a href=\"{{pluginbaseurl}}/view.php?id={{id}}\" target=\"_blank\">{{name}}</a></li>{{/policies}}</ul>";
+                   "<ul>{{#policies}}<li><a href=\"{{pluginbaseurl}}/view.php?policyid={{id}}&returnurl={{returnurl}}\">{{name}}</a></li>{{/policies}}</ul>";
                 var continuemessage = "{{# str }} guestconsent:continue, tool_policy {{/ str }}";
 
                 // Initialize popup.

--- a/admin/tool/policy/templates/page_viewdoc.mustache
+++ b/admin/tool/policy/templates/page_viewdoc.mustache
@@ -1,0 +1,52 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    Template for viewing a policy version document.
+
+    Classes required for JS:
+    -
+
+    Data attributes required for JS:
+    -
+
+    Context variables required for this template:
+    * error - array with errors to show.
+    * navigation - array of navigation buttons.
+    * version - version document object.
+}}
+
+{{#error}}
+{{{.}}}
+{{/error}}
+
+<div class='policy-heading'>
+{{#version.name}}
+<h1>{{version.name}}</h1>
+
+{{#version.content}}
+<div class='policy-content'>
+{{{version.content}}}
+</div>
+<div class="policy-viewdoc-buttons">
+{{#navigation}}
+    {{{.}}}
+{{/navigation}}
+</div>
+{{/version.content}}
+
+
+{{/version.name}}

--- a/admin/tool/policy/view.php
+++ b/admin/tool/policy/view.php
@@ -1,0 +1,40 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * View current document policy version.
+ *
+ * @package     tool_policy
+ * @copyright   2018 Sara Arjona (sara@moodle.com)
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require(__DIR__.'/../../../config.php');
+
+$policyid = required_param('policyid', PARAM_INT);
+$versionid = optional_param('versionid', 0, PARAM_INT);
+$returnurl  = optional_param('returnurl', null, PARAM_LOCALURL);
+
+$urlparams = array('policyid' => $policyid, 'versionid' => $versionid);
+$url = new moodle_url('/admin/tool/policy/view.php', $urlparams);
+list($title, $subtitle) = \tool_policy\page_helper::setup_for_public_page($url);
+
+$output = $PAGE->get_renderer('tool_policy');
+$page = new \tool_policy\output\page_viewdoc($policyid, $versionid, $returnurl);
+
+echo $output->header();
+echo $output->render($page);
+echo $output->footer();


### PR DESCRIPTION
- If returnurl parameter is defined, a back button will be shown at the end of the doc.
- Only users with tool/policy:managedocs capability will be able to view draft versions.

@mudrd8mz I've added some constants to the API and created a function to get the status of a version (to avoid show draft versions to users without the capability tool/policy:managedocs). We should replace the "draft", "archive" and "current" references in other files (like page_managedocs_document.php) for using these constats.

BTW, with current version, if you try to view a policyid and/or versionid which doesn't exist, a database error is shown. The API expect that the policyid and versionid must exists, so we need to add some extra checks in the get_policy_version function. Are you agree or there is some good reason for moving these checks to the renderer? :-) 