### PR TITLE
MDL-61302 policy: Fix some minor errors and review consent page

### DIFF
--- a/admin/tool/policy/classes/output/guestconsent.php
+++ b/admin/tool/policy/classes/output/guestconsent.php
@@ -54,13 +54,9 @@ class guestconsent implements renderable, templatable {
         $data->pluginbaseurl = (new moodle_url('/admin/tool/policy'))->out(true);
         $data->returnurl = qualified_me();
 
-        $policies = \tool_policy\api::list_policies();
+        $policies = \tool_policy\api::list_policies(null, true);
         foreach ($policies as $policy) {
             // TODO: Filter guest policies.
-            // Filter policies valid for guests with some current version.
-            if (!isset($policy->currentversionid)) {
-                unset($policies[$policy->id]);
-            }
         }
         $data->policies = array_values($policies);
 

--- a/admin/tool/policy/classes/output/page_agreedocs.php
+++ b/admin/tool/policy/classes/output/page_agreedocs.php
@@ -59,7 +59,7 @@ class page_agreedocs implements renderable, templatable {
      *
      * @param int $userid The userid which wants to view this policy version.
      */
-    public function __construct($userid = 0) {
+    public function __construct($userid = 0, $policies = null) {
         global $USER;
 
         $this->userid = $userid;
@@ -70,7 +70,10 @@ class page_agreedocs implements renderable, templatable {
             $this->user = core_user::get_user($userid, '*', MUST_EXIST);
         }
 
-        $this->policies = \tool_policy\api::list_policies();
+        $this->policies = $policies;
+        if (!isset($this->policies)) {
+            $this->policies = \tool_policy\api::list_policies(null, true);
+        }
         $currentlanguage = current_language();
         $acceptances = \tool_policy\api::get_user_acceptances($this->userid);
         foreach ($this->policies as $policy) {
@@ -80,7 +83,8 @@ class page_agreedocs implements renderable, templatable {
                 $this->policies[$policy->id]->currentversion = $policy->versions[$policy->currentversionid];
                 unset($this->policies[$policy->id]->versions);
 
-                $policy->url = new moodle_url('/admin/tool/policy/view.php', array('policyid' => $policy->id));
+                $policy->url = new moodle_url('/admin/tool/policy/view.php', array('policyid' => $policy->id, 'returnurl' => qualified_me()));
+                // TODO: Replace current link to policy document to open it in a modal window.
                 $policylinkname = html_writer::link($policy->url, $policy->name);
 
                 // Check if this policy version has been agreed or not.
@@ -105,6 +109,7 @@ class page_agreedocs implements renderable, templatable {
                     $this->policies[$policy->id]->versionlangsagreed = get_string('policyversionacceptedinotherlang', 'tool_policy');
                 }
                 // TODO: Mark as mandatory this checkbox (style).
+                $this->policies[$policy->id]->refertofulltext = get_string('refertofullpolicytext', 'tool_policy', $policylinkname);
                 $this->policies[$policy->id]->agreecheckbox = html_writer::checkbox('agreedoc[]', $policy->id, $versionagreed, get_string('iagree', 'tool_policy', $policylinkname));
             }
         }

--- a/admin/tool/policy/classes/output/page_viewdoc.php
+++ b/admin/tool/policy/classes/output/page_viewdoc.php
@@ -114,11 +114,11 @@ class page_viewdoc implements renderable, templatable {
 
             $data->navigation = array();
             if (!empty($this->returnurl)) {
-                $backbutton = new single_button(
+                $button = new single_button(
                    new moodle_url($this->returnurl),
-                   get_string('back'), 'get'
+                   get_string('continue'), 'get'
                 );
-                $data->navigation[] = $output->render($backbutton);
+                $data->navigation[] = $output->render($button);
             }
         }
         return $data;

--- a/admin/tool/policy/index.php
+++ b/admin/tool/policy/index.php
@@ -27,10 +27,6 @@ require(__DIR__.'/../../../config.php');
 $agreedoc =optional_param_array('agreedoc', null, PARAM_INT);
 $userid = optional_param('userid', null, PARAM_INT);
 
-$urlparams = array();
-$url = new moodle_url('/admin/tool/policy/index.php', $urlparams);
-list($title, $subtitle) = \tool_policy\page_helper::setup_for_agreedocs_page($url);
-
 if (!empty($SESSION->wantsurl)) {
     $return = $SESSION->wantsurl;
 } else {
@@ -38,40 +34,59 @@ if (!empty($SESSION->wantsurl)) {
 }
 
 if (isguestuser()) {
+    unset($SESSION->wantsurl);
     redirect($return);
 }
+
+$urlparams = array();
+if (!empty($userid)) {
+    $urlparams['userid'] = $userid;
+}
+$url = new moodle_url('/admin/tool/policy/index.php', $urlparams);
+list($title, $subtitle) = \tool_policy\page_helper::setup_for_agreedocs_page($url);
 
 if (empty($userid)) {
     $userid = $USER->id;
 }
 
-$usercontext = \context_user::instance($userid);
 if ($userid == $USER->id) {
     require_capability('tool/policy:accept', context_system::instance());
 } else {
+    $usercontext = \context_user::instance($userid);
     require_capability('tool/policy:acceptbehalf', $usercontext);
 }
 
+$policies = \tool_policy\api::list_policies(null, true);
 if (!empty($agreedoc) && confirm_sesskey()) {
+    $currentlanguage = current_language();
     // Accept / revoke policies.
     $acceptversionids = array();
-    foreach($agreedoc as $policyid) {
-        $policy = tool_policy\api::get_policy($policyid);
-        $acceptversionids[] = $policy->currentversionid;
+    foreach ($policies as $policy) {
+        if (in_array($policy->id, $agreedoc)) {
+            // Save policy version doc to accept it.
+            $acceptversionids[] = $policy->currentversionid;
+        } else {
+            // TODO: Revoke policy doc.
+            //\tool_policy\api::revoke_acceptance($policy->currentversionid, $userid, null, $currentlanguage);
+        }
     }
-    \tool_policy\api::accept_policies($acceptversionids, $userid, null, current_language());
-    // TODO: Revoke acceptances.
-    //\tool_policy\api::revoke_acceptance($acceptversionids, $userid, null, current_language());
+    // Accept all policy docs saved in $acceptversionids.
+    \tool_policy\api::accept_policies($acceptversionids, $userid, null, $currentlanguage);
 }
 
-// If the user hasn't any policy versions to agreed to, redirect to return page.
+// If the user current user has the policyagreed = 1, redirect to the return page.
 if (!is_siteadmin() && $USER->id == $userid && $USER->policyagreed) {
+    unset($SESSION->wantsurl);
     redirect($return);
 }
 
+// Redirect to policy docs before the consent page.
+\tool_policy\page_helper::redirect_to_policies($userid, $policies, $url);
+
+// Show the consent page.
 $output = $PAGE->get_renderer('tool_policy');
 
 echo $output->header();
-$page = new \tool_policy\output\page_agreedocs($userid);
+$page = new \tool_policy\output\page_agreedocs($userid, $policies);
 echo $output->render($page);
 echo $output->footer();

--- a/admin/tool/policy/lang/en/tool_policy.php
+++ b/admin/tool/policy/lang/en/tool_policy.php
@@ -86,17 +86,11 @@ $string['policydocsummary_help'] = 'This text should provide a summary of the po
 $string['policydocs'] = 'Policy documents';
 $string['policyversionacceptedinotherlang'] = 'This policy version has been accepted previously in a different language.';
 $string['privacyofficer'] = 'Privacy officer';
-$string['privacyofficer_desc'] = 'Information and contact details of the privacy officer.';
-$string['privacyofficer_default'] = 'For any questions or notice, please contact our Privacy officer at:
-
-Institution/Company name
-Address, 1
-State (Country)
-
-Email: xxxxxx@xxxxx.xxx
-Phone: yyyyyyyy';
+// TODO: Review the list of places where the privacyofficer will be shown.
+$string['privacyofficer_desc'] = 'Information and contact details of the privacy officer, such as the address, email. phone... This information will be shown to the users in the consent page.';
 $string['privacysettings'] = 'Privacy settings';
 $string['proceed'] = 'Proceed';
+$string['refertofullpolicytext'] = 'Please refer to the full {$a} text if you would like to review.';
 $string['saveasnew'] = 'Save as new version';
 $string['saveasnew_help'] = 'Should the text be saved as a new version of the policy text?
 

--- a/admin/tool/policy/settings.php
+++ b/admin/tool/policy/settings.php
@@ -77,7 +77,7 @@ if ($hassiteconfig || has_any_capability($managecaps, context_system::instance()
             'tool_policy/privacyofficer',
             new lang_string('privacyofficer', 'tool_policy'),
             new lang_string('privacyofficer_desc', 'tool_policy'),
-            new lang_string('privacyofficer_default', 'tool_policy'),
+            '',
             PARAM_RAW
         ));
     }

--- a/admin/tool/policy/templates/page_agreedocs.mustache
+++ b/admin/tool/policy/templates/page_agreedocs.mustache
@@ -28,6 +28,8 @@
     * privacyofficer - string
 }}
 
+{{! TODO: Review styles }}
+
 {{{startform}}}
 
 {{#user}}
@@ -45,8 +47,13 @@
     <div class='agreedoc-summary'>
       {{{description}}}
     </div>
-    {{{agreecheckbox}}}
-    {{{versionlangsagreed}}}
+    <div class='agreedoc-form'>
+        <p>{{{refertofulltext}}}</p>
+        <p>
+            {{{agreecheckbox}}}
+            {{{versionlangsagreed}}}
+        </p>
+    </div>
 
 {{/policies}}
 

--- a/admin/tool/policy/tests/api_test.php
+++ b/admin/tool/policy/tests/api_test.php
@@ -112,6 +112,11 @@ class tool_policy_api_testcase extends advanced_testcase {
         $policy = api::get_policy($policy->policyid);
         $this->assertEquals($policy->currentversionid, $updated->versionid);
 
+        // Get just the activated policies.
+        $docs = api::list_policies(null, true);
+        $this->assertEquals(1, count($docs));
+        $this->assertEquals($docs[$policy->policyid]->currentversionid, $updated->versionid);
+
         // Activate another policy version.
         api::make_current($policy->policyid, $new->versionid);
         $policy = api::get_policy($policy->policyid);


### PR DESCRIPTION
- Review consent page for displaying before the non-accepted policy docs.
- Fix some minor errors.
- Added extra parameter to list_policies, for filter policies with current version.

I've realised that the tool_policy_acceptances.language was renamed some days ago. So at the moment, as all functions in api.php use the "language" field name, to make it work it's necessary to rename the database field from lang to language. Tomorrow I'll try to fix it :-)
