### PR TITLE
MDL-61302 policy: Review lang field

### DIFF
--- a/admin/tool/policy/classes/output/guestconsent.php
+++ b/admin/tool/policy/classes/output/guestconsent.php
@@ -56,7 +56,10 @@ class guestconsent implements renderable, templatable {
 
         $policies = \tool_policy\api::list_policies(null, true);
         foreach ($policies as $policy) {
-            // TODO: Filter guest policies.
+            if ($policy->audience != \tool_policy\api::AUDIENCE_ALL && $policy->audience != \tool_policy\api::AUDIENCE_GUESTS) {
+                // Remove policies which are not addressed to guests.
+                unset($policies[$policy->id]);
+            }
         }
         $data->policies = array_values($policies);
 

--- a/admin/tool/policy/classes/output/page_agreedocs.php
+++ b/admin/tool/policy/classes/output/page_agreedocs.php
@@ -99,7 +99,7 @@ class page_agreedocs implements renderable, templatable {
         $acceptances = \tool_policy\api::get_user_acceptances($this->userid);
         foreach ($this->policies as $policy) {
             // Get only current version object. Remove the other versions from the object because at this point they aren't needed.
-            $this->policies[$policy->id]->currentversion = $policy->versions[$policy->currentversionid];
+            $this->policies[$policy->id]->currentversion = \tool_policy\api::get_policy_version($policy->id, $policy->currentversionid);
             unset($this->policies[$policy->id]->versions);
 
             // Get the link to display the full policy document.

--- a/admin/tool/policy/index.php
+++ b/admin/tool/policy/index.php
@@ -58,7 +58,7 @@ if ($userid == $USER->id) {
 
 $policies = \tool_policy\api::list_policies(null, true);
 if (!empty($agreedoc) && confirm_sesskey()) {
-    $currentlanguage = current_language();
+    $lang = current_language();
     // Accept / revoke policies.
     $acceptversionids = array();
     foreach ($policies as $policy) {
@@ -67,11 +67,11 @@ if (!empty($agreedoc) && confirm_sesskey()) {
             $acceptversionids[] = $policy->currentversionid;
         } else {
             // TODO: Revoke policy doc.
-            //\tool_policy\api::revoke_acceptance($policy->currentversionid, $userid, null, $currentlanguage);
+            //\tool_policy\api::revoke_acceptance($policy->currentversionid, $userid);
         }
     }
     // Accept all policy docs saved in $acceptversionids.
-    \tool_policy\api::accept_policies($acceptversionids, $userid, null, $currentlanguage);
+    \tool_policy\api::accept_policies($acceptversionids, $userid, null, $lang);
 }
 
 // If the user current user has the policyagreed = 1, redirect to the return page.

--- a/admin/tool/policy/lang/en/tool_policy.php
+++ b/admin/tool/policy/lang/en/tool_policy.php
@@ -87,7 +87,8 @@ $string['policydocrevisioncurrent'] = 'Current revision';
 $string['policydocsummary'] = 'Summary';
 $string['policydocsummary_help'] = 'This text should provide a summary of the policy, potentially in a simplified and easily accessible form, using clear and plain language.';
 $string['policydocs'] = 'Policy documents';
-$string['policyversionacceptedinotherlang'] = 'This policy version has been accepted previously in a different language.';
+$string['policyversionacceptedinbehalf'] = 'This policy version has been previously accepted by another user on behalf of you.';
+$string['policyversionacceptedinotherlang'] = 'This policy version has been previously accepted in a different language.';
 $string['privacyofficer'] = 'Privacy officer';
 // TODO: Review the list of places where the privacyofficer will be shown.
 $string['privacyofficer_desc'] = 'Information and contact details of the privacy officer, such as the address, email. phone... This information will be shown to the users in the consent page.';

--- a/admin/tool/policy/templates/page_agreedocs.mustache
+++ b/admin/tool/policy/templates/page_agreedocs.mustache
@@ -51,7 +51,12 @@
         <p>{{{refertofulltext}}}</p>
         <p>
             {{{agreecheckbox}}}
-            {{{versionlangsagreed}}}
+            {{#versionlangsagreed}}
+                <br/>{{{.}}}
+            {{/versionlangsagreed}}
+            {{#versionbehalfsagreed}}
+                <br/>{{{.}}}
+            {{/versionbehalfsagreed}}
         </p>
     </div>
 

--- a/admin/tool/policy/templates/page_agreedocs.mustache
+++ b/admin/tool/policy/templates/page_agreedocs.mustache
@@ -39,13 +39,9 @@
 {{#policies}}
 
     <div class='agreedoc'>
-    {{! TODO: Review which fields to use for showing policy version summay.
-        ATM, name and description are used, but it's possible we'll need to replace
-        them to new summary field.
-     }}
     <h2>{{{name}}}</h2>
     <div class='agreedoc-summary'>
-      {{{description}}}
+      {{{currentversion.summary}}}
     </div>
     <div class='agreedoc-form'>
         <p>{{{refertofulltext}}}</p>


### PR DESCRIPTION
- Fix some minor errors detected on previous PR, such as:
  - Use INNER JOIN instead of WHERE.
  - Remove lang from the accept_policies function (only first accepted language is saved on database).
- Replace language database field references to lang (was renamed some days ago).
- Add the policy version summary field to the consent page.
- Filter policies for guests based on the new audience field.