### PR TITLE
MDL-61302 policy: Prepare index for being used during the signup process

### DIFF
--- a/admin/tool/policy/classes/page_helper.php
+++ b/admin/tool/policy/classes/page_helper.php
@@ -44,10 +44,10 @@ use stdClass;
 class page_helper {
 
     /**
-     * Set-up a public page.
+     * Set-up a page.
      *
      * Example:
-     * list($title, $subtitle) = page_helper::setup_for_public_page($url, $pagetitle);
+     * list($title, $subtitle) = page_helper::setup_for_page($url, $pagetitle);
      * echo $OUTPUT->heading($title);
      * echo $OUTPUT->heading($subtitle, 3);
      *
@@ -57,54 +57,13 @@ class page_helper {
      *               - Page title
      *               - Page sub title
      */
-    public static function setup_for_public_page(moodle_url $url, $subtitle = '') {
-        global $PAGE, $SITE;
-
-        $context = \context_system::instance();
-        $PAGE->set_context($context);
-
-        if (!empty($subtitle)) {
-            $title = $subtitle;
-        } else {
-            $title = get_string('policiesagreements', 'tool_policy');
-        }
-
-        $heading = $SITE->fullname;
-        $PAGE->set_pagelayout('standard');
-        $PAGE->set_url($url);
-        $PAGE->set_title($title);
-        $PAGE->set_heading($heading);
-
-        return array($title, $subtitle);
-    }
-
-    /**
-     * Set-up the policy acceptance page.
-     *
-     * Example:
-     * list($title, $subtitle) = page_helper::setup_for_agreedocs_page($url, $pagetitle);
-     * echo $OUTPUT->heading($title);
-     * echo $OUTPUT->heading($subtitle, 3);
-     *
-     * @param  moodle_url $url The current page.
-     * @param  string $subtitle The title of the subpage, if any.
-     * @return array With the following:
-     *               - Page title
-     *               - Page sub title
-     */
-    public static function setup_for_agreedocs_page(moodle_url $url, $subtitle = '') {
+    public static function setup_for_page(moodle_url $url, $subtitle = '') {
         global $PAGE, $SITE;
 
         $PAGE->set_popup_notification_allowed(false);
 
-        // Check if the user is logged in, to avoid deadlock.
-        if (!isloggedin()) {
-            require_login();
-        }
-
         $context = \context_system::instance();
         $PAGE->set_context($context);
-
 
         if (!empty($subtitle)) {
             $title = $subtitle;
@@ -137,10 +96,12 @@ class page_helper {
         }
         $lang = current_language();
         $acceptances = \tool_policy\api::get_user_acceptances($userid);
-        foreach($policies as $policy) {
-            if (\tool_policy\api::is_user_version_accepted($userid, $policy->currentversionid, $acceptances)) {
-                // If this version is accepted by the user, remove from the pending policies list.
-                unset($policies[$policy->id]);
+        if (!empty($userid)) {
+            foreach($policies as $policy) {
+                if (\tool_policy\api::is_user_version_accepted($userid, $policy->currentversionid, $acceptances)) {
+                    // If this version is accepted by the user, remove from the pending policies list.
+                    unset($policies[$policy->id]);
+                }
             }
         }
 

--- a/admin/tool/policy/classes/validateminor_helper.php
+++ b/admin/tool/policy/classes/validateminor_helper.php
@@ -100,12 +100,14 @@ class validateminor_helper {
      * @param bool $is_minor
      */
     public static function redirect($is_minor) {
+        global $SESSION;
 
         if ($is_minor) {
             redirect(new \moodle_url('/admin/tool/policy/contactadmin.php'));
-        } else {
-            // TODO: Redirect to "Policy" pages.
-            die("Policy page");
+        } else if (empty($SESSION->userpolicyagreed)) {
+            // Redirect to "Policy" pages for consenting before creating the user.
+            $SESSION->wantsurl = new \moodle_url('/login/signup.php');
+            redirect(new \moodle_url('/admin/tool/policy/index.php'));
         }
     }
 

--- a/admin/tool/policy/view.php
+++ b/admin/tool/policy/view.php
@@ -31,7 +31,7 @@ $userid = optional_param('userid', 0, PARAM_INT);
 
 $urlparams = array('policyid' => $policyid, 'versionid' => $versionid);
 $url = new moodle_url('/admin/tool/policy/view.php', $urlparams);
-list($title, $subtitle) = \tool_policy\page_helper::setup_for_public_page($url);
+list($title, $subtitle) = \tool_policy\page_helper::setup_for_page($url);
 
 $output = $PAGE->get_renderer('tool_policy');
 $page = new \tool_policy\output\page_viewdoc($policyid, $versionid, $returnurl, $userid);


### PR DESCRIPTION
- Added the specific call to index.php from the admin/tool/policy/classes/validateminor_helper.php.
- Adapted the consent page to let also new users ($USER->id = 0) to access.
- Renamed setup_for_public_page to setup_for_page. Now is used in both index.php and view.php.